### PR TITLE
DATA-336 add security changes to the BasicKubernetesPodOperator

### DIFF
--- a/mojap_airflow_tools/constants.py
+++ b/mojap_airflow_tools/constants.py
@@ -1,4 +1,4 @@
-ecr_base_path = "593291632749.dkr.ecr.eu-west-1.amazonaws.com/"
+ecr_base_path = "189157455002.dkr.ecr.eu-west-1.amazonaws.com/"
 
 ECR_TEMPLATE = "{account_number}.dkr.ecr.eu-west-1.amazonaws.com/{repo_name}:{release}"
 DEFAULT_ACC_NUMBER = "189157455002"

--- a/mojap_airflow_tools/operators.py
+++ b/mojap_airflow_tools/operators.py
@@ -154,6 +154,7 @@ def basic_kubernetes_pod_operator(
             task_id=task_id,
             get_logs=True,
             service_account_name=f"{user}-jupyter",
+            pod_template_file="/usr/local/airflow/dags/.kube/default_pod_spec.yaml",
             **kwargs,
         )
     else:
@@ -172,6 +173,7 @@ def basic_kubernetes_pod_operator(
             get_logs=True,
             annotations={"iam.amazonaws.com/role": role},
             security_context=security_context,
+            pod_template_file="/usr/local/airflow/dags/.kube/default_pod_spec.yaml",
             **kwargs,
         )
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -51,6 +51,7 @@ def test_no_errors(repo, tag, full):
         "runAsNonRoot": True,
         "privileged": False,
     }
+    assert k.pod_template_file == "/usr/local/airflow/dags/.kube/default_pod_spec.yaml"
 
     expected_env = [
         V1EnvVar(


### PR DESCRIPTION
This has a corresponding PR in [data-engineering-airflow](github.com/ministryofjustice/data-engineering-airflow/pulls), in which there is added the new default pod template file for the BasicKubernetesOperator. The [order of precedence](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/operators.html#argument-precedence) for these settings means users specifying their own image files will have precedence over the image specified here. This should not be merged until it's sister PR has first been merged, to ensure the file will exist in all envs.

This is a minor change, as we already force users to upload dags that have precedence over all settings in this template -  however it is still best practice to specify a template of minimal permissions.